### PR TITLE
Add 'types' key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/arafel/captchajs",
   "author": "Paul Walker (https://github.com/arafel)",
   "license": "MIT",
+  "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Shows TypeScript (and editors) where to find the types for the package.

Closes #4