### PR TITLE
Disable "yarn audit" on 'ci' task.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "release": "release-it",
     "dev:build": "tsc -w",
     "dev:test": "jest --watch",
-    "ci": "yarn audit --high && yarn test"
+    "ci": "yarn test"
   },
   "dependencies": {
     "dayjs": "^1.11.5",


### PR DESCRIPTION
It's causing problems where sometimes we can't merge changes due to a problem in a package 4 levels down that's only used for making releases.

(vm2, I'm looking at you.)

https://github.com/TooTallNate/proxy-agents/issues/218#issuecomment-1636441524 https://github.com/release-it/release-it/issues/1024#issuecomment-1638503017