### PR TITLE
Build types etc. on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dev:build": "tsc -w",
     "dev:test": "jest --watch",
     "ci": "yarn test",
-    "prepare": "pwd && tsc && ls build/"
+    "prepare": "tsc"
   },
   "dependencies": {
     "dayjs": "^1.11.5",


### PR DESCRIPTION
Use the 'prepare' script to run tsc, producing the compiled JavaScript and types in the build/ directory.