### PR TITLE
test: fix coverage

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -172,6 +172,10 @@ describe("random string validation", () => {
     o = new CaptchaJs({ client: "demo", secret: "secret" });
   });
 
+  test("reject an empty random string", () => {
+    expect(o.validateRandomString()).toBeFalsy();
+  })
+
   test("reject a random string we didn't generate", () => {
     expect(o.validateRandomString("I am a test string")).toBeFalsy();
   })


### PR DESCRIPTION
Add a simple test with no random string parameter; it was a gap in the testing and it was causing incomplete coverage. (Fixes #44.)
